### PR TITLE
feat: decompile base image and show possible errors in it

### DIFF
--- a/pkg/command/analyzer.go
+++ b/pkg/command/analyzer.go
@@ -62,10 +62,10 @@ func AnalyzeFile(file *os.File) []error {
 		}
 	}
 
-	return AnalyzeNode(res.AST)
-}
-func AnalyzeNode(node *parser.Node) []error {
-	return AnalyzeNodeFromSource(node, utils.Image)
+	return AnalyzeNodeFromSource(res.AST, utils.Source{
+		Name: "",
+		Type: utils.Image,
+	})
 }
 
 func AnalyzeNodeFromSource(node *parser.Node, source utils.Source) []error {
@@ -81,7 +81,7 @@ func AnalyzeNodeFromSource(node *parser.Node, source utils.Source) []error {
 		if handler != nil {
 			for n := child.Next; n != nil; n = n.Next {
 				if n.Value == "" {
-					suggestions = append(suggestions, fmt.Errorf("%s %s has an empty value", child.Value, PrintLineInfo(line)))
+					suggestions = append(suggestions, fmt.Errorf("%s %s has an empty value", child.Value, GenerateErrorLocation(source, line)))
 				} else {
 					suggestions = append(suggestions, handler.Analyze(n, source, line)...)
 				}
@@ -95,7 +95,10 @@ func IsCommand(text string, command string) bool {
 	return strings.Contains(text, command)
 }
 
-func PrintLineInfo(line Line) string {
+func GenerateErrorLocation(source utils.Source, line Line) string {
+	if source.Type == utils.Parent {
+		return fmt.Sprintf("in parent image %s", source.Name)
+	}
 	if line.Start == line.End {
 		return fmt.Sprintf("at line %d", line.Start)
 	}

--- a/pkg/command/analyzer.go
+++ b/pkg/command/analyzer.go
@@ -12,6 +12,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/redhat-developer/docker-openshift-analyzer/pkg/decompiler"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,6 +53,17 @@ func AnalyzePath(path string) []error {
 	defer file.Close()
 
 	return AnalyzeFile(file)
+}
+
+func AnalyzeImage(image string) []error {
+	node, err := decompiler.Decompile(image)
+	if err != nil {
+		return []error{fmt.Errorf("unable to analyze %s - error %s", image, err)}
+	}
+	return AnalyzeNodeFromSource(node, utils.Source{
+		Name: "",
+		Type: utils.Image,
+	})
 }
 
 func AnalyzeFile(file *os.File) []error {

--- a/pkg/command/expose.go
+++ b/pkg/command/expose.go
@@ -28,7 +28,7 @@ func (e Expose) Analyze(node *parser.Node, source utils.Source, line Line) []err
 		errs = append(errs, err)
 	}
 	if port < 1024 {
-		errs = append(errs, fmt.Errorf(`port %d exposed %s could be wrong. TCP/IP port numbers below 1024 are privileged port numbers`, port, PrintLineInfo(line)))
+		errs = append(errs, fmt.Errorf(`port %d exposed %s could be wrong. TCP/IP port numbers below 1024 are privileged port numbers`, port, GenerateErrorLocation(source, line)))
 	}
 	return errs
 }

--- a/pkg/command/expose.go
+++ b/pkg/command/expose.go
@@ -15,12 +15,13 @@ import (
 	"strconv"
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"github.com/redhat-developer/docker-openshift-analyzer/pkg/utils"
 )
 
 type Expose struct {
 }
 
-func (e Expose) Analyze(node *parser.Node, line Line) []error {
+func (e Expose) Analyze(node *parser.Node, source utils.Source, line Line) []error {
 	errs := []error{}
 	port, err := strconv.Atoi(node.Value)
 	if err != nil {

--- a/pkg/command/from.go
+++ b/pkg/command/from.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Red Hat, Inc.
+ * Copyright (c) 2023 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -12,18 +12,26 @@ package command
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"github.com/redhat-developer/docker-openshift-analyzer/pkg/decompiler"
 	"github.com/redhat-developer/docker-openshift-analyzer/pkg/utils"
 )
 
-type User struct{}
+type From struct {
+}
 
-func (u User) Analyze(node *parser.Node, source utils.Source, line Line) []error {
+func (f From) Analyze(node *parser.Node, source utils.Source, line Line) []error {
 	errs := []error{}
-	if strings.EqualFold(node.Value, "root") {
-		errs = append(errs, fmt.Errorf(`USER directive set to root %s could cause an unexpected behavior. In OpenShift, containers are run using arbitrarily assigned user ID`, PrintLineInfo(line)))
+	decompiledNode, err := decompiler.Decompile(node.Value)
+	if err != nil {
+		// unable to decompile base image
+		errs = append(errs, fmt.Errorf("unable to analyze the base image %s", node.Value))
+		return errs
+	}
+	errsFromBaseImage := AnalyzeNodeFromSource(decompiledNode, utils.Parent)
+	if len(errsFromBaseImage) > 0 {
+		errs = append(errs, errsFromBaseImage...)
 	}
 	return errs
 }

--- a/pkg/command/from.go
+++ b/pkg/command/from.go
@@ -29,7 +29,10 @@ func (f From) Analyze(node *parser.Node, source utils.Source, line Line) []error
 		errs = append(errs, fmt.Errorf("unable to analyze the base image %s", node.Value))
 		return errs
 	}
-	errsFromBaseImage := AnalyzeNodeFromSource(decompiledNode, utils.Parent)
+	errsFromBaseImage := AnalyzeNodeFromSource(decompiledNode, utils.Source{
+		Name: node.Value,
+		Type: utils.Parent,
+	})
 	if len(errsFromBaseImage) > 0 {
 		errs = append(errs, errsFromBaseImage...)
 	}

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -59,7 +59,7 @@ func (r Run) analyzeSudoAndSuCommand(s string, source utils.Source, line Line) e
 	if len(match) > 0 {
 		return fmt.Errorf(`sudo/su command used in '%s' %s could cause an unexpected behavior. 
 		In OpenShift, containers are run using arbitrarily assigned user ID and elevating privileges could lead 
-		to an unexpected behavior`, s, PrintLineInfo(line))
+		to an unexpected behavior`, s, GenerateErrorLocation(source, line))
 	}
 	return nil
 }
@@ -87,7 +87,7 @@ func (r Run) analyzeChownCommand(s string, source utils.Source, line Line) error
 	group := match[len(match)-1]
 	if strings.ToLower(group) != "root" && group != "0" {
 		return fmt.Errorf(`owner set on %s %s could cause an unexpected behavior. 
-		In OpenShift the group ID must always be set to the root group (0)`, s, PrintLineInfo(line))
+		In OpenShift the group ID must always be set to the root group (0)`, s, GenerateErrorLocation(source, line))
 	}
 	return nil
 }
@@ -103,11 +103,11 @@ func (r Run) analyzeChmodCommand(s string, source utils.Source, line Line) error
 		return nil
 	}
 	if len(match) != 3 {
-		return fmt.Errorf("unable to fetch args of chmod command %s. Is it correct?", PrintLineInfo(line))
+		return fmt.Errorf("unable to fetch args of chmod command %s. Is it correct?", GenerateErrorLocation(source, line))
 	}
 	permission := match[1]
 	if len(permission) != 3 {
-		return fmt.Errorf("unable to fetch args of chmod command %s. Is it correct?", PrintLineInfo(line))
+		return fmt.Errorf("unable to fetch args of chmod command %s. Is it correct?", GenerateErrorLocation(source, line))
 	}
 	groupPermission := permission[1:2]
 	if groupPermission != "7" {
@@ -117,7 +117,7 @@ func (r Run) analyzeChmodCommand(s string, source utils.Source, line Line) error
 		}
 		return fmt.Errorf("permission set on %s %s could cause an unexpected behavior. %s\n"+
 			"Explanation - in Openshift, directories and files need to be read/writable by the root group and "+
-			"files that must be executed should have group execute permissions", s, PrintLineInfo(line), proposal)
+			"files that must be executed should have group execute permissions", s, GenerateErrorLocation(source, line), proposal)
 	}
 
 	return nil

--- a/pkg/command/user.go
+++ b/pkg/command/user.go
@@ -23,7 +23,7 @@ type User struct{}
 func (u User) Analyze(node *parser.Node, source utils.Source, line Line) []error {
 	errs := []error{}
 	if strings.EqualFold(node.Value, "root") {
-		errs = append(errs, fmt.Errorf(`USER directive set to root %s could cause an unexpected behavior. In OpenShift, containers are run using arbitrarily assigned user ID`, PrintLineInfo(line)))
+		errs = append(errs, fmt.Errorf(`USER directive set to root %s could cause an unexpected behavior. In OpenShift, containers are run using arbitrarily assigned user ID`, GenerateErrorLocation(source, line)))
 	}
 	return errs
 }

--- a/pkg/decompiler/decompiler.go
+++ b/pkg/decompiler/decompiler.go
@@ -67,7 +67,7 @@ func Decompile(imageName string) (*parser.Node, error) {
 	history := configFile.History
 	sort.Sort(OrderedHistory(history))
 	for _, hist := range history {
-		if hist.Comment != "" && strings.HasPrefix(hist.Comment, "FROM ") {
+		if hist.Comment != "" && strings.HasPrefix(strings.ToUpper(hist.Comment), utils.FROM_INSTRUCTION) {
 			err := line2Node(hist.Comment, root)
 			if err != nil {
 				return nil, err
@@ -85,7 +85,7 @@ func Decompile(imageName string) (*parser.Node, error) {
 	}
 
 	if configFile.Config.User != "" {
-		err := line2Node("USER "+configFile.Config.User, root)
+		err := line2Node(utils.USER_INSTRUCTION+configFile.Config.User, root)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +112,7 @@ func extractCmd(str string) string {
 	}
 	index = strings.Index(str, utils.RUN_PREFIX)
 	if index >= 0 {
-		return "RUN " + str[index+len(utils.RUN_PREFIX):]
+		return utils.RUN_INSTRUCTION + str[index+len(utils.RUN_PREFIX):]
 	}
 	if isContainerFileInstruction(str) {
 		return str
@@ -122,7 +122,7 @@ func extractCmd(str string) string {
 
 func isContainerFileInstruction(str string) bool {
 	for _, prefix := range CONTAINERFILE_INSTRUCTIONS {
-		if strings.HasPrefix(str, prefix) {
+		if strings.HasPrefix(strings.ToUpper(str), prefix) {
 			return true
 		}
 	}

--- a/pkg/decompiler/decompiler.go
+++ b/pkg/decompiler/decompiler.go
@@ -66,13 +66,8 @@ func Decompile(imageName string) (*parser.Node, error) {
 
 	history := configFile.History
 	sort.Sort(OrderedHistory(history))
+	processed := false
 	for _, hist := range history {
-		if hist.Comment != "" && strings.HasPrefix(strings.ToUpper(hist.Comment), utils.FROM_INSTRUCTION) {
-			err := line2Node(hist.Comment, root)
-			if err != nil {
-				return nil, err
-			}
-		}
 		if hist.CreatedBy != "" {
 			cmd := extractCmd(hist.CreatedBy)
 			if cmd != "" {
@@ -80,6 +75,13 @@ func Decompile(imageName string) (*parser.Node, error) {
 				if err != nil {
 					return nil, err
 				}
+				processed = true
+			}
+		}
+		if !processed && hist.Comment != "" && strings.HasPrefix(strings.ToUpper(hist.Comment), utils.FROM_INSTRUCTION) {
+			err := line2Node(hist.Comment, root)
+			if err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/pkg/decompiler/decompiler.go
+++ b/pkg/decompiler/decompiler.go
@@ -66,8 +66,14 @@ func Decompile(imageName string) (*parser.Node, error) {
 
 	history := configFile.History
 	sort.Sort(OrderedHistory(history))
-	processed := false
 	for _, hist := range history {
+		if hist.Comment != "" && strings.HasPrefix(strings.ToUpper(hist.Comment), utils.FROM_INSTRUCTION) &&
+			!hist.EmptyLayer {
+			err := line2Node(hist.Comment, root)
+			if err != nil {
+				return nil, err
+			}
+		}
 		if hist.CreatedBy != "" {
 			cmd := extractCmd(hist.CreatedBy)
 			if cmd != "" {
@@ -75,13 +81,6 @@ func Decompile(imageName string) (*parser.Node, error) {
 				if err != nil {
 					return nil, err
 				}
-				processed = true
-			}
-		}
-		if !processed && hist.Comment != "" && strings.HasPrefix(strings.ToUpper(hist.Comment), utils.FROM_INSTRUCTION) {
-			err := line2Node(hist.Comment, root)
-			if err != nil {
-				return nil, err
 			}
 		}
 	}

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -23,9 +23,14 @@ const STOPSIGNAL_INSTRUCTION = "STOPSIGNAL "
 const HEALTHCHECK_INSTRUCTION = "HEALTHCHECK "
 const SHELL_INSTRUCTION = "SHELL "
 
-type Source string
+type SourceType string
 
 const (
-	Image  Source = "IMAGE"
-	Parent Source = "PARENT_IMAGE"
+	Image  SourceType = "IMAGE"
+	Parent SourceType = "PARENT_IMAGE"
 )
+
+type Source struct {
+	Name string
+	Type SourceType
+}

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -4,6 +4,7 @@ const NOP = "#(nop) "
 
 const RUN_PREFIX = "/bin/sh -c "
 
+const FROM_INSTRUCTION = "FROM "
 const RUN_INSTRUCTION = "RUN "
 const CMD_INSTRUCTION = "CMD "
 const LABEL_INSTRUCTION = "LABEL "
@@ -21,3 +22,10 @@ const ONBUILD_INSTRUCTION = "ONBUILD "
 const STOPSIGNAL_INSTRUCTION = "STOPSIGNAL "
 const HEALTHCHECK_INSTRUCTION = "HEALTHCHECK "
 const SHELL_INSTRUCTION = "SHELL "
+
+type Source string
+
+const (
+	Image  Source = "IMAGE"
+	Parent Source = "PARENT_IMAGE"
+)

--- a/test/command/run_test.go
+++ b/test/command/run_test.go
@@ -93,13 +93,6 @@ func TestFailChmodCommandWithUserSetButNotGroup(t *testing.T) {
 	}
 }
 
-func TestFailChmodCommandWithMissingPermission(t *testing.T) {
-	suggestions := verifyParsingCommand(t, "chmod /app", 1)
-	if !strings.Contains(suggestions[0].Error(), "unable to fetch args of chmod command") {
-		t.Errorf("Expected to be unable to fetch args of chmod command but it was %s", suggestions[0].Error())
-	}
-}
-
 func TestFailChmodCommandWithInvalidPermissionCode(t *testing.T) {
 	suggestions := verifyParsingCommand(t, "chmod 70 /app", 1)
 	if !strings.Contains(suggestions[0].Error(), "unable to fetch args of chmod command") {
@@ -112,7 +105,10 @@ func verifyParsingCommand(t *testing.T, cmd string, numberExpectedErrors int) []
 	suggestions := run.Analyze(&parser.Node{
 		Value: cmd,
 	},
-		utils.Image,
+		utils.Source{
+			Name: "test",
+			Type: utils.Image,
+		},
 		command.Line{
 			Start: 1,
 			End:   1,

--- a/test/command/run_test.go
+++ b/test/command/run_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/redhat-developer/docker-openshift-analyzer/pkg/command"
+	"github.com/redhat-developer/docker-openshift-analyzer/pkg/utils"
 )
 
 /*
@@ -111,6 +112,7 @@ func verifyParsingCommand(t *testing.T, cmd string, numberExpectedErrors int) []
 	suggestions := run.Analyze(&parser.Node{
 		Value: cmd,
 	},
+		utils.Image,
 		command.Line{
 			Start: 1,
 			End:   1,


### PR DESCRIPTION
I created a parent image with some errors and then used it on another one. 
Parent Image
```
FROM node:10

# Setup workdir
WORKDIR /usr/src/app
COPY package*.json ./

USER root
RUN npm install

COPY . .

# run
EXPOSE 30
CMD ["node", "index.js"]
```

Child
```
FROM quay.io/lstocchi/node-wrongportanduser
CMD ["echo", "Hello!"]
```

When analyzing the child Dockerfile the suggestions are displayed like this
```
1 - USER directive set to root in parent image quay.io/lstocchi/node-wrongportanduser could cause an unexpected behavior. In OpenShift, containers are run using arbitrarily assigned user ID

2 - port 30 exposed in parent image quay.io/lstocchi/node-wrongportanduser could be wrong. TCP/IP port numbers below 1024 are privileged port numbers

3 - USER directive set to root in parent image quay.io/lstocchi/node-wrongportanduser could cause an unexpected behavior. In OpenShift, containers are run using arbitrarily assigned user ID
```

The problem that can occur is that the image have not the full path. E.g if in the child image i add "lstocchi/node-wrongportanduser" our tool does not know where to look for the parent image and could fail. How do we overcome this?